### PR TITLE
Cleaned up Makefile and dependency install scripts for Mac and Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,103 +1,122 @@
-CPP_SOURCES=ksp_plugin/plugin.cpp ksp_plugin/interface.cpp ksp_plugin/physics_bubble.cpp 
-PROTO_SOURCES=$(wildcard */*.proto)
-PROTO_CC_SOURCES=$(wildcard serialization/*.cc)
-PROTO_OBJECTS=$(PROTO_CC_SOURCES:.cc=.o)
+CXX := clang++
 
-OBJECTS=$(CPP_SOURCES:.cpp=.o)
-VERSION_HEADER=base/version.hpp
-PROTO_HEADERS=$(PROTO_SOURCES:.proto=.pb.h)
 
-LIB_DIR=Debug/GameData/Principia
-LIB=$(LIB_DIR)/principia.so
+VERSION_HEADER := base/version.hpp
 
-DEP_DIR=deps
+CPP_SOURCES := ksp_plugin/plugin.cpp ksp_plugin/interface.cpp ksp_plugin/physics_bubble.cpp 
+PROTO_SOURCES := $(wildcard */*.proto)
+PROTO_CC_SOURCES := $(PROTO_SOURCES:.proto=.pb.cc)
+PROTO_HEADERS := $(PROTO_SOURCES:.proto=.pb.h)
 
-TEST_INCLUDE=-I$(DEP_DIR)/gmock/include -I$(DEP_DIR)/gtest/include -I$(DEP_DIR)/gmock -I$(DEP_DIR)/gtest
-INCLUDE=-I. -I$(DEP_DIR)/glog/src -I$(DEP_DIR)/protobuf/src -I$(DEP_DIR)/benchmark/include $(TEST_INCLUDE)
+OBJECTS := $(CPP_SOURCES:.cpp=.o)
+PROTO_OBJECTS := $(PROTO_CC_SOURCES:.cc=.o)
+TEST_DIRS := base geometry integrators ksp_plugin_test physics quantities testing_utilities
+TEST_BINS := $(addsuffix /test,$(TEST_DIRS))
 
-CPPC=clang++
-SHARED_ARGS=-std=c++1y -stdlib=libc++ -O3 -g -m64 -fPIC -fexceptions -ferror-limit=0 -fno-omit-frame-pointer # -Wall -Wpedantic 
-COMPILE_ARGS=-c $(SHARED_ARGS) $(INCLUDE)
-LINK_ARGS=$(SHARED_ARGS) 
-LIB_PATHS=-L$(DEP_DIR)/glog/.libs/ -L$(DEP_DIR)/benchmark/src/ -L$(DEP_DIR)/protobuf/src/.libs/ -L$(DEP_DIR)/gmock/lib/.libs/
-LIBS=-l:libc++.a -l:libprotobuf.a -l:libglog.a -lpthread
+ADAPTER_BUILD_DIR := ksp_plugin_adapter/obj
+ADAPTER_CONFIGURATION := Debug
+FINAL_PRODUCTS_DIR := Debug
+ADAPTER := $(ADAPTER_BUILD_DIR)/$(ADAPTER_CONFIGURATION)/ksp_plugin_adapter.dll
 
-all: $(DEP_DIR) $(LIB) run_tests
+LIB_DIR := $(FINAL_PRODUCTS_DIR)/GameData/Principia
+LIB := $(LIB_DIR)/principia.so
 
-adapter:
-	mdtool build ksp_plugin_adapter/ksp_plugin_adapter.csproj
+DEP_DIR := deps
+LIBS := $(DEP_DIR)/protobuf/src/.libs/libprotobuf.a $(DEP_DIR)/glog/.libs/libglog.a -lpthread
+TEST_INCLUDES := -I$(DEP_DIR)/gmock/include -I$(DEP_DIR)/gtest/include -I$(DEP_DIR)/gmock -I$(DEP_DIR)/gtest
+INCLUDES := -I. -I$(DEP_DIR)/glog/src -I$(DEP_DIR)/protobuf/src -I$(DEP_DIR)/benchmark/include $(TEST_INCLUDES)
+SHARED_ARGS := -std=c++1y -stdlib=libc++ -O3 -g -fPIC -fexceptions -ferror-limit=0 -fno-omit-frame-pointer -Wall -Wpedantic 
 
-$(LIB): $(VERSION_HEADER) $(PROTO_HEADERS) $(OBJECTS) $(PROTO_OBJECTS) Makefile adapter
-	$(CPPC) -shared $(LINK_ARGS) $(OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) -o $(LIB) $(LIB_PATHS) $(LIBS) 
+# detect OS
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    UNAME_P := $(shell uname -p)
+    ifeq ($(UNAME_P),x86_64)
+        SHARED_ARGS += -m64
+    else
+        SHARED_ARGS += -m32
+    endif
+    MDTOOL := mdtool
+endif
+ifeq ($(UNAME_S),Darwin)
+    SHARED_ARGS += -mmacosx-version-min=10.7 -arch i386
+    MDTOOL ?= "/Applications/Xamarin Studio.app/Contents/MacOS/mdtool"
+endif
+
+CXXFLAGS := -c $(SHARED_ARGS) $(INCLUDES)
+LDFLAGS := $(SHARED_ARGS)
+
+
+.PHONY: all adapter lib tests check plugin run_tests clean
+.DEFAULT_GOAL := plugin
+
+##### CONVENIENCE TARGETS #####
+all: $(LIB) $(ADAPTER) tests
+
+adapter: $(ADAPTER)
+lib: $(LIB)
+
+tests: $(TEST_BINS)
+
+check: tests run_tests
+
+##### CORE #####
+$(ADAPTER):
+	$(MDTOOL) build -c:$(ADAPTER_CONFIGURATION) ksp_plugin_adapter/ksp_plugin_adapter.csproj
+
+$(LIB): $(VERSION_HEADER) $(PROTO_HEADERS) $(PROTO_OBJECTS) $(OBJECTS)
+	$(CXX) -shared $(LDFLAGS) $(PROTO_OBJECTS) $(OBJECTS) -o $(LIB) $(LIBS) 
 
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
 
-$(DEP_DIR):
-	./install_deps.sh
-
 $(VERSION_HEADER): .git
 	./generate_version_header.sh
 
-%.pb.h: %.proto
+%.pb.cc %.pb.h: %.proto
 	$(DEP_DIR)/protobuf/src/protoc $< --cpp_out=.
 
 %.o: %.cpp 
-	$(CPPC) $(COMPILE_ARGS) $< -o $@ 
+	$(CXX) $(CXXFLAGS) $< -o $@ 
 
 %.o: %.cc $(PROTO_HEADERS)
-	$(CPPC) $(COMPILE_ARGS) $< -o $@ 
+	$(CXX) $(CXXFLAGS) $< -o $@ 
+
+##### DISTRIBUTION #####
+plugin: $(LIB) $(ADAPTER)
+	cd $(LIB_DIR)/..; zip -r Principia-$(UNAME_S)-$(shell git rev-parse --short HEAD)-$(shell date "+%Y-%m-%d").zip Principia/
 
 ##### TESTS #####
-TEST_BINS=base/test geometry/test integrators/test ksp_plugin_test/test physics/test quantities/test testing_utilities/test
-run_tests: $(TEST_BINS)
-	base/test; true
-	geometry/test; true
-	integrators/test; true
-	ksp_plugin_test/test; true
-	physics/test; true
-	quantities/test; true
-	testing_utilities/test; true
+run_tests:
+	-base/test
+	-geometry/test
+	-integrators/test
+	-ksp_plugin_test/test
+	-physics/test
+	-quantities/test
+	-testing_utilities/test
 
-TEST_LIBS=-l:libc++.a -l:libprotobuf.a -l:libglog.a -lpthread
+TEST_LIBS=$(DEP_DIR)/protobuf/src/.libs/libprotobuf.a $(DEP_DIR)/glog/.libs/libglog.a -lpthread
 
 GMOCK_SOURCE=$(DEP_DIR)/gmock/src/gmock-all.cc $(DEP_DIR)/gmock/src/gmock_main.cc $(DEP_DIR)/gtest/src/gtest-all.cc
 GMOCK_OBJECTS=$(GMOCK_SOURCE:.cc=.o)
 
-BASE_TEST_SOURCES=$(wildcard base/*.cpp)
-BASE_TEST_OBJECTS=$(BASE_TEST_SOURCES:.cpp=.o)
-base/test: $(GMOCK_OBJECTS) $(BASE_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(BASE_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
+test_objects = $(patsubst %.cpp,%.o,$(wildcard $*/*.cpp))
+ksp_plugin_test_objects = $(patsubst %.cpp,%.o,$(wildcard ksp_plugin/*.cpp)) $(patsubst %.cpp,%.o,$(wildcard ksp_plugin_test/*.cpp))
 
-GEOMETRY_TEST_SOURCES=$(wildcard geometry/*.cpp)
-GEOMETRY_TEST_OBJECTS=$(GEOMETRY_TEST_SOURCES:.cpp=.o)
-geometry/test: $(GMOCK_OBJECTS) $(GEOMETRY_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(GEOMETRY_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
+# We need to special-case ksp_plugin_test because it requires object files from ksp_plugin. The other tests don't do this.
+.SECONDEXPANSION:
+ksp_plugin_test/test: $$(ksp_plugin_test_objects) $(GMOCK_OBJECTS) $(PROTO_OBJECTS)
+	$(CXX) $(LDFLAGS) $^ $(TEST_LIBS) -o $@
 
-INTEGRATOR_TEST_SOURCES=$(wildcard integrators/*.cpp)
-INTEGRATOR_TEST_OBJECTS=$(INTEGRATOR_TEST_SOURCES:.cpp=.o)
-integrators/test: $(GMOCK_OBJECTS) $(INTEGRATOR_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(INTEGRATOR_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
+.SECONDEXPANSION:
+%/test: $$(test_objects) $(GMOCK_OBJECTS) $(PROTO_OBJECTS)
+	$(CXX) $(LDFLAGS) $^ $(TEST_LIBS) -o $@
 
-PLUGIN_TEST_SOURCES=$(wildcard ksp_plugin_test/*.cpp) $(wildcard ksp_plugin/*.cpp)
-PLUGIN_TEST_OBJECTS=$(PLUGIN_TEST_SOURCES:.cpp=.o)
-ksp_plugin_test/test: $(GMOCK_OBJECTS) $(PLUGIN_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(PLUGIN_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
+##### CLEAN #####
+clean_test-%:
+	rm -f $(test_objects)
 
-PHYSICS_TEST_SOURCES=$(wildcard physics/*.cpp)
-PHYSICS_TEST_OBJECTS=$(PHYSICS_TEST_SOURCES:.cpp=.o)
-physics/test: $(GMOCK_OBJECTS) $(PHYSICS_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(PHYSICS_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
-
-QUANTITIES_TEST_SOURCES=$(wildcard quantities/*.cpp)
-QUANTITIES_TEST_OBJECTS=$(QUANTITIES_TEST_SOURCES:.cpp=.o)
-quantities/test: $(GMOCK_OBJECTS) $(QUANTITIES_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(QUANTITIES_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
-
-TESTING_UTILITIES_TEST_SOURCES=$(wildcard testing_utilities/*.cpp)
-TESTING_UTILITIES_TEST_OBJECTS=$(TESTING_UTILITIES_TEST_SOURCES:.cpp=.o)
-testing_utilities/test: $(GMOCK_OBJECTS) $(TESTING_UTILITIES_TEST_OBJECTS) $(PROTO_OBJECTS) Makefile
-	$(CPPC) $(LINK_ARGS) $(TESTING_UTILITIES_TEST_OBJECTS) $(GMOCK_OBJECTS) $(PROTO_OBJECTS) $(INCLUDE) $(LIB_PATHS) $(TEST_LIBS) -o $@
-
-clean:
-	rm -f $(LIB) $(PROTO_HEADERS) $(OBJECTS) $(PROTO_OBJECTS) $(BASE_TEST_OBJECTS) $(GEOMETRY_TEST_OBJECTS) $(INTEGRATOR_TEST_OBJECTS) $(PLUGIN_TEST_OBJECTS) $(PHYSICS_TEST_OBJS) $(QUANTITIES_TEST_OBJECTS) $(TESTING_UTILITIES_TEST_OBJECTS) $(TEST_BINS)
+clean:  $(addprefix clean_test-,$(TEST_DIRS))
+	rm -rf $(ADAPTER_BUILD_DIR) $(FINAL_PRODUCTS_DIR)
+	rm -f $(LIB) $(VERSION_HEADER) $(PROTO_HEADERS) $(PROTO_CC_SOURCES) $(OBJECTS) $(PROTO_OBJECTS) $(TEST_BINS) $(LIB) $(ksp_plugin_test_objects)

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,7 +1,29 @@
 #!/bin/bash
 
-echo "apt-get installing: clang git unzip wget libc++-dev binutils make automake libtool curl cmake subversion"
-sudo apt-get install clang git unzip wget libc++-dev binutils make automake libtool curl cmake subversion
+echo "Required prerequisites for build: build-essential clang libc++-dev monodevelop subversion git"
+echo "Required runtime dependencies: libc++1"
+
+#sudo apt-get install clang git unzip wget libc++-dev binutils make automake libtool curl cmake subversion
+
+BASE_FLAGS="-fPIC -O3 -g"
+# determine platform for bitness
+
+PLATFORM=$(uname -s)
+if [ "$PLATFORM" == "Darwin" ]; then
+    C_FLAGS="$BASE_FLAGS -mmacosx-version-min=10.7 -arch i386"
+elif [ "$PLATFORM" == "Linux" ]; then
+	BITNESS=$(uname -p)
+	if [ "$BITNESS" == "x86_64"]; then
+	  C_FLAGS="$BASE_FLAGS -m64"
+        else
+      	   C_FLAGS="$BASE_FLAGS -m32"
+        fi
+else
+    C_FLAGS="$BASE_FLAGS"
+fi
+
+LD_FLAGS="$C_FLAGS -stdlib=libc++"
+CXX_FLAGS="-std=c++1y $LD_FLAGS"
 
 mkdir -p deps
 cd deps
@@ -10,23 +32,39 @@ git clone "https://github.com/google/protobuf.git" --depth 1 -b "v3.0.0-alpha-1"
 pushd protobuf
 git am "../../documentation/Setup Files/protobuf.patch"
 ./autogen.sh
-./autogen.sh # Makefile.in ends up being missing unless we run this twice??
-./configure CC=clang CXX=clang++ CXXFLAGS='-fPIC -m64 -std=c++11 -stdlib=libc++ -O3 -g' LDFLAGS='-stdlib=libc++'
-make -j 8
-
+./configure CC=clang CXX=clang++ CXXFLAGS="$CXX_FLAGS" LDFLAGS="$LD_FLAGS"
+make -j8
 popd
+
 git clone https://github.com/Norgg/glog
 pushd glog
-./configure CC=clang CXX=clang++ CXXFLAGS='-fPIC -m64 -std=c++11 -stdlib=libc++ -O3 -g' LDFLAGS='-stdlib=libc++'
-make -j 8
-
+./configure CC=clang CXX=clang++ CFLAGS="$C_FLAGS" CXXFLAGS="$CXX_FLAGS" LDFLAGS="$LD_FLAGS"
+make -j8
 popd
-svn checkout http://googlemock.googlecode.com/svn/trunk/ gmock
+
 svn checkout http://googletest.googlecode.com/svn/trunk/ gtest
 pushd gtest
 wget "https://gist.githubusercontent.com/Norgg/241ee11d278c0a55cc96/raw/4b23a866c6631ba0077229be366e67cde18fb035/gtest_linux_thread_count.patch" -O thread_count.patch
 patch -p 0 -i thread_count.patch
-
+# gtest does not need to be compiled
 popd
+
+svn checkout http://googlemock.googlecode.com/svn/trunk/ gmock
 pushd gmock
 patch -p 1 -i "../../documentation/Setup Files/gmock.patch"; true
+# gmock does not need to be compiled
+popd
+
+# there's a bug in benchmark on 32-bit
+#git clone https://github.com/google/benchmark
+#pushd benchmark
+#cmake -DCMAKE_CXX_FLAGS="$CXX_FLAGS" .
+#make
+#popd
+
+#git clone "https://chromium.googlesource.com/chromium/src.git" chromium -n --depth 1 -b "40.0.2193.1"
+#pushd chromium
+#git config core.sparsecheckout true
+#cp "../../documentation/Setup Files/chromium_sparse_checkout.txt" .git/info/sparse-checkout
+#git checkout
+#git am "../../documentation/Setup Files/chromium.patch"


### PR DESCRIPTION
Lots of changes here — please look over it and test on Linux :)

Just `make` builds the plugin and adapter and packages them.
`make all` builds the plugin, adapter, and tests.
`make check` actually runs the tests (building them if necessary). (This follows the convention for standard targets.)
`make clean` cleans up all built products.
